### PR TITLE
a bug in "sample/dcgm/deviceinfo/main.go

### DIFF
--- a/bindings/go/dcgm/topology.go
+++ b/bindings/go/dcgm/topology.go
@@ -56,7 +56,7 @@ func (l P2PLinkType) PCIPaths() string {
 }
 
 type P2PLink struct {
-	GPU   uint
+	GpuID uint
 	BusID string
 	Link  P2PLinkType
 }
@@ -126,7 +126,7 @@ func getDeviceTopology(gpuid uint) (links []P2PLink, err error) {
 	for i := uint(0); i < uint(topology.numGpus); i++ {
 		gpu := topology.gpuPaths[i].gpuId
 		p2pLink := P2PLink{
-			GPU:   uint(gpu),
+			GpuID: uint(gpu),
 			BusID: busid,
 			Link:  getP2PLink(uint(topology.gpuPaths[i].path)),
 		}

--- a/bindings/go/samples/dcgm/deviceInfo/main.go
+++ b/bindings/go/samples/dcgm/deviceInfo/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 	"text/template"
-
+	//"../../../dcgm"
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm"
 )
 
@@ -28,7 +28,7 @@ Memory (MHz)           : {{or .Clocks.Memory "N/A"}}
 Power (W)              : {{or .Power "N/A"}}
 CPUAffinity            : {{or .CPUAffinity "N/A"}}
 P2P Available          : {{if not .Topology}}None{{else}}{{range .Topology}}
-    GPU{{.GpuId}} - (BusID){{.BusID}} - {{.Link.PCIPaths}}{{end}}{{end}}
+			(GPU){{.GPU}} - (BusID){{.BusID}} - {{.Link.PCIPaths}}{{end}}{{end}}
 ---------------------------------------------------------------------
 `
 )

--- a/bindings/go/samples/dcgm/deviceInfo/main.go
+++ b/bindings/go/samples/dcgm/deviceInfo/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"text/template"
 	//"../../../dcgm"
-	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm"
+  	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm"
 )
 
 const (
@@ -28,7 +28,7 @@ Memory (MHz)           : {{or .Clocks.Memory "N/A"}}
 Power (W)              : {{or .Power "N/A"}}
 CPUAffinity            : {{or .CPUAffinity "N/A"}}
 P2P Available          : {{if not .Topology}}None{{else}}{{range .Topology}}
-			(GPU){{.GPU}} - (BusID){{.BusID}} - {{.Link.PCIPaths}}{{end}}{{end}}
+			(GPU){{.GpuID}} - (BusID){{.BusID}} - {{.Link.PCIPaths}}{{end}}{{end}}
 ---------------------------------------------------------------------
 `
 )


### PR DESCRIPTION
In the `bind/go/sample/dcgm/deviceInfo/main.go` file, there is an error in the definition of deviceInfo. If the GPU device supports DCGM, the following error message will appear:
`Template error: Template: Device: 19:10: Execute "Device" in <.GpuID>: Cannot evaluate field GpuID in dcgm.P2PLink type`

Here I modified the variable "GPU" in the P2PLink structure in the `bindings / go / dcgm / topology.go` file to "GpuID" to fix it.