### PR TITLE
[Pod GPU Metrics Exporter] Fix GPU metrics watcher stuck

### DIFF
--- a/exporters/prometheus-dcgm/k8s/pod-gpu-metrics-exporter/src/watchers.go
+++ b/exporters/prometheus-dcgm/k8s/pod-gpu-metrics-exporter/src/watchers.go
@@ -41,12 +41,11 @@ func watchAndWriteGPUmetrics() {
 				podMap, err := getDevicePodInfo(socketPath)
 				if err != nil {
 					glog.Error(err)
-					return
+					continue
 				}
 				err = addPodInfoToMetrics(gpuPodMetricsPath, gpuMetrics, gpuPodMetrics, podMap)
 				if err != nil {
 					glog.Error(err)
-					return
 				}
 			}
 


### PR DESCRIPTION
When kubelet is unavailable temporally, `watchAndWriteGPUmetrics()` return empty and will be to do nothing.

The patch fixes this kind of issue.