### PR TITLE
Add gpu_type and device count to metrics

### DIFF
--- a/exporters/prometheus-dcgm/dcgm-exporter/dcgm-exporter
+++ b/exporters/prometheus-dcgm/dcgm-exporter/dcgm-exporter
@@ -55,7 +55,7 @@ if [ "${DCP_METRICS}" = "yes" ]; then
 fi
 
 dcgmi dmon -d "${COLLECT_INTERVAL_MS}" -e \
-"54,"\
+"50,54,"\
 "100,101,"\
 "140,150,155,156,"\
 "200,201,202,203,204,206,207,"\
@@ -72,15 +72,26 @@ function metric(name, type, help, value) {
         if (gpu == 0) {
             printf "# HELP dcgm_%s %s\n", name, help > out".swp"
             printf "# TYPE dcgm_%s %s\n", name, type > out".swp"
+
+            if (name == "device_count") {
+                printf "dcgm_%s %s\n", name, value > out".swp"
+            }
         }
-        printf "dcgm_%s{gpu=\"%s\",uuid=\"%s\"} %s\n", name, gpu, uuid, value > out".swp"
+
+        if (name != "device_count") {
+            printf "dcgm_%s{gpu=\"%s\",uuid=\"%s\",gpu_type=\"%s\"} %s\n", name, gpu, uuid, gpu_type, value > out".swp"
+        }
     }
 }
 (NF && NR > 2 && !($1 ~ "^#" || $1 ~ "^Id")) {
     # Labels
     i = 1
     gpu = $(i++)                                                                                                      # field 0 (implicit)
+    gpu_type = $(i++)"-"$(i++)                                                                                        # field 50
     uuid = $(i++)                                                                                                     # field 54
+
+    # Device count metric
+    metric("device_count", "gauge", "Device count.", ngpus)                                                           # device count
 
     # Clocks
     metric("sm_clock", "gauge", "SM clock frequency (in MHz).", $(i++))                                               # field 100


### PR DESCRIPTION
Clone of PR #30 with syntax fix.

Results: 
```
# HELP dcgm_device_count Device count.
# TYPE dcgm_device_count gauge
dcgm_device_count 1
# HELP dcgm_sm_clock SM clock frequency (in MHz).
# TYPE dcgm_sm_clock gauge
dcgm_sm_clock{gpu="0",uuid="GPU-deecc6f6-2684-6d54-00fa-b419a8a56a56",gpu_type="Tesla-V100-SXM2-16GB"} 135
# HELP dcgm_memory_clock Memory clock frequency (in MHz).
# TYPE dcgm_memory_clock gauge
dcgm_memory_clock{gpu="0",uuid="GPU-deecc6f6-2684-6d54-00fa-b419a8a56a56",gpu_type="Tesla-V100-SXM2-16GB"} 877

```

When I build my image and try to run on a GPU machine, there's some error message but seems the metrics are fine

```
docker run --runtime=nvidia --rm --name=nvidia-dcgm-exporter ${my_image}

Failed to get unit file state for nvidia-fabricmanager.service: Unknown error 1203220864
Starting NVIDIA host engine...
Collecting metrics at /run/prometheus/dcgm.prom every 1000ms...
```
Does anyone have clue on `Failed to get unit file state for nvidia-fabricmanager.service`
