### PR TITLE
added affinity field in daemonset

### DIFF
--- a/deployment/dcgm-exporter/templates/daemonset.yaml
+++ b/deployment/dcgm-exporter/templates/daemonset.yaml
@@ -97,7 +97,10 @@ spec:
           initialDelaySeconds: 5
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Previously affinity field had no effect. Now it will be added to daemonset template definition, if will be specified.