### PR TITLE
remove docker user  dcgm-exporter

### DIFF
--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -20,8 +20,7 @@ COPY etc/dcgm-exporter /etc/dcgm-exporter
 
 ENV NVIDIA_VISIBLE_DEVICES=all
 
-RUN useradd dcgm-exporter
-USER dcgm-exporter
+USER root
 
 ARG VERSION
 

--- a/docker/Dockerfile.ubuntu18.04
+++ b/docker/Dockerfile.ubuntu18.04
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV NVIDIA_VISIBLE_DEVICES=all
 
-RUN useradd dcgm-exporter
-USER dcgm-exporter
+USER root
 
 ENTRYPOINT ["/usr/bin/dcgm-exporter"]


### PR DESCRIPTION
dose it necessary for use user: dcgm-exporter in doker and change it to user:0 in pod.spec?

https://github.com/NVIDIA/gpu-monitoring-tools/blob/2.0.0-rc.11/dcgm-exporter.yaml#L49
