### PR TITLE
Fix DCGM exporter daemonset env variable

### DIFF
--- a/dcgm-exporter.yaml
+++ b/dcgm-exporter.yaml
@@ -39,7 +39,7 @@ spec:
         - name: "DCGM_EXPORTER_LISTEN"
           value: "9400"
         - name: "DCGM_EXPORTER_KUBERNETES"
-          value: true
+          value: "true"
         name: "dcgm-exporter"
         ports:
         - name: "metrics"


### PR DESCRIPTION
Without this patch, applying the ``dcgm-exporter.yaml`` manifest results
in this error:

```
  Error from server (BadRequest): error when creating
  "dcgm-exporter.yaml": DaemonSet in version "v1" cannot be handled as a
  DaemonSet: v1.DaemonSet.Spec: v1.DaemonSetSpec.Template:
  v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container:
  v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects "
  or n, but found t, error found in #10 byte of
  ...|,"value":true}],"ima|..., bigger context
  ...|400"},{"name":"DCGM_EXPORTER_KUBERNETES","value":true}],"image":"nvidia/dcgm-exporter:1.7.2","name":|...
```

This is because ``true`` is a YAML keyword that gets evaluated to a
boolean type, while the EnvVar type expects a string. This patch fixes
the issue by quoting the environment variable value.

There is related ongoing work in kubernetes' YAML parsing libraries[1]
but this is not completed and may not address parsing of boolean
keywords.

[1] https://github.com/kubernetes/kubernetes/issues/82296