### PR TITLE
Filter out metrics with no value

### DIFF
--- a/pkg/gpu_collector.go
+++ b/pkg/gpu_collector.go
@@ -69,18 +69,24 @@ func (c *DCGMCollector) GetMetrics() ([][]Metric, error) {
 }
 
 func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device) []Metric {
-	metrics := make([]Metric, len(values))
+	var metrics []Metric
 
 	for i, val := range values {
-		metrics[i] = Metric{
+		v := ToString(val)
+		// Filter out counters with no value
+		if v == "9223372036854775794" {
+			continue
+		}
+		m := Metric{
 			Name:  c[i].FieldName,
-			Value: ToString(val),
+			Value: v,
 
 			GPU:     fmt.Sprintf("%d", d.GPU),
 			GPUUUID: d.UUID,
 
 			Attributes: map[string]string{},
 		}
+		metrics = append(metrics, m)
 	}
 
 	return metrics


### PR DESCRIPTION
I noticed many metrics had a value of 9223372036854775794 which even appears in the README. As best I could tell these were metrics that had no value, like on a system without NVLINK the NVLINK metrics all had this value.  Rather than having this non-value mess up graphs and reporting, this PR filters those values out so they are just not seen by Prometheus. This is the way metrics with no value are supposed to be handled with Prometheus. Even giving the value `NaN` would cause problems as that's technically stored as a float64 in Prometheus.