### PR TITLE
Change kubeVersion constrain to support eks/gke

### DIFF
--- a/deployment/dcgm-exporter/Chart.yaml
+++ b/deployment/dcgm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dcgm-exporter
 description: A Helm chart for DCGM exporter
 version: "2.1.0"
-kubeVersion: ">= 1.13.0"
+kubeVersion: ">= 1.13.0-0"
 appVersion: "2.1.0"
 sources:
 - https://gitlab.com/nvidia/container-toolkit/gpu-monitoring-tools


### PR DESCRIPTION
Fixes 

```
Error: chart requires kubeVersion: >= 1.13.0 which is incompatible with Kubernetes v1.17.9-eks-4c6976
```