### PR TITLE
Fix spacing in each metrics line

### DIFF
--- a/pkg/pipeline.go
+++ b/pkg/pipeline.go
@@ -165,7 +165,7 @@ func FormatCounters(c []Counter) (string, error) {
 
 var metricsFormat = `
 {{ range $dev := . }}{{ range $val := $dev }}
-{{ $val.Name }}{gpu="{{ $val.GPU }}", UUID="{{ $val.GPUUUID }}", device="{{ $val.GPUDevice }}"
+{{ $val.Name }}{gpu="{{ $val.GPU }}",UUID="{{ $val.GPUUUID }}",device="{{ $val.GPUDevice }}"
 
 {{- range $k, $v := $val.Attributes -}}
 	,{{ $k }}="{{ $v }}"


### PR DESCRIPTION
Signed-off-by: Srikanth <srikanth.hanagud@gmail.com>

This isn't a problem when using prometheus, but when used with openmetrics, it complains of whitespace. I got this issue when I try to use openmetrics to push this metrics to datadog.

More information about the issue is here - https://github.com/prometheus/docs/issues/543#issuecomment-247335229

Please let me know in case you need further information.

