### PR TITLE
#169 Support extra config map volumes on dcgm-exporter helm-chart

### DIFF
--- a/deployment/dcgm-exporter/templates/daemonset.yaml
+++ b/deployment/dcgm-exporter/templates/daemonset.yaml
@@ -63,6 +63,9 @@ spec:
         hostPath:
           path: {{ .hostPath | quote }}
       {{- end }}
+      {{- with .Values.extraConfigMapVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: exporter
         securityContext:

--- a/deployment/dcgm-exporter/values.yaml
+++ b/deployment/dcgm-exporter/values.yaml
@@ -96,6 +96,11 @@ extraHostVolumes: []
 #- name: host-binaries
 #  hostPath: /opt/bin
 
+extraConfigMapVolumes: []
+#- name: exporter-metrics-volume
+#  configMap:
+#    name: exporter-metrics-config-map
+
 extraVolumeMounts: []
 #- name: host-binaries
 #  mountPath: /opt/bin


### PR DESCRIPTION
As requested on #169

To be used for adding custom metrics CSV using a config map