### PR TITLE
Fix GPUDevice to Model

### DIFF
--- a/pkg/gpu_collector.go
+++ b/pkg/gpu_collector.go
@@ -112,7 +112,8 @@ func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device, instanceI
 			UUID:      uuid,
 			GPU:       fmt.Sprintf("%d", d.GPU),
 			GPUUUID:   d.UUID,
-			GPUDevice: d.Identifiers.Model,
+			GPUDevice: fmt.Sprintf("nvidia%d", d.GPU),
+			GPUModel:  d.Identifiers.Model,
 			Hostname:  hostname,
 
 			Attributes: map[string]string{},

--- a/pkg/gpu_collector.go
+++ b/pkg/gpu_collector.go
@@ -112,7 +112,7 @@ func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device, instanceI
 			UUID:      uuid,
 			GPU:       fmt.Sprintf("%d", d.GPU),
 			GPUUUID:   d.UUID,
-			GPUDevice: fmt.Sprintf("nvidia%d", d.GPU),
+			GPUDevice: d.Identifiers.Model,
 			Hostname:  hostname,
 
 			Attributes: map[string]string{},

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -42,6 +42,7 @@ var (
 	CLIRemoteHEInfo        = "remote-hostengine-info"
 	CLIDevices             = "devices"
 	CLINoHostname          = "no-hostname"
+	CLIModels              = "models"
 )
 
 func main() {
@@ -121,6 +122,13 @@ func main() {
 			Value:   false,
 			Usage:   "Omit the hostname information from the output, matching older versions.",
 			EnvVars: []string{"DCGM_EXPORTER_NO_HOSTNAME"},
+		},
+		&cli.BoolFlag{
+			Name:    CLIModels,
+			Aliases: []string{"m"},
+			Value:   false,
+			Usage:   "Enable to display GPU Models",
+			EnvVars: []string{"DCGM_EXPORTER_MODELS_STR"},
 		},
 	}
 
@@ -309,5 +317,6 @@ func contextToConfig(c *cli.Context) (*Config, error) {
 		RemoteHEInfo:        c.String(CLIRemoteHEInfo),
 		Devices:             dOpt,
 		NoHostname:          c.Bool(CLINoHostname),
+		Models:              c.Bool(CLIModels),
 	}, nil
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -56,7 +56,7 @@ func main() {
 		"MIG mode is disabled.\n\tg = Monitor all GPUs\n\ti = Monitor all GPU instances\n\tg+i = " +
 		"monitor all GPUs and GPU instances\n\tg:0,1 = monitor GPUs 0 and 1\n\ti:0,2-4 = monitor GPU " +
 		"instances 0, 2, 3, and 4.\n\n\tNOTE 1: i cannot be specified unless MIG mode is enabled.\n" +
-		"NOTE 2: Any time indices are specified, those indicies must exist on the system.\nNOTE 3: " +
+		"NOTE 2: Any time indices are specified, those indices must exist on the system.\nNOTE 3: " +
 		"In in MIG mode -f and -g+i (without indices) effectively have the same result."
 
 	c.Flags = []cli.Flag{

--- a/pkg/pipeline.go
+++ b/pkg/pipeline.go
@@ -113,7 +113,7 @@ func (m *MetricsPipeline) Run(out chan string, stop chan interface{}, wg *sync.W
 }
 
 func (m *MetricsPipeline) run() (string, error) {
-	metrics, err := m.gpuCollector.GetMetrics()
+	metrics, err := m.gpuCollector.GetMetrics(m.config)
 	if err != nil {
 		return "", fmt.Errorf("Failed to collect metrics with error: %v", err)
 	}
@@ -167,8 +167,7 @@ func FormatCounters(c []Counter) (string, error) {
 
 var metricsFormat = `
 {{ range $dev := . }}{{ range $val := $dev }}
-{{ $val.Name }}{gpu="{{ $val.GPU }}",{{ $val.UUID }}="{{ $val.GPUUUID }}",device="{{ $val.GPUDevice }}"
-
+{{ $val.Name }}{gpu="{{ $val.GPU }}",{{ $val.UUID }}="{{ $val.GPUUUID }}",device="{{ $val.GPUDevice }}"{{if $val.GPUModel }},model="{{ $val.GPUModel }}"{{end}}
 {{- range $k, $v := $val.Attributes -}}
 	,{{ $k }}="{{ $v }}"
 {{- end -}}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -113,6 +113,7 @@ type Metric struct {
 	GPU       string
 	GPUUUID   string
 	GPUDevice string
+	GPUModel  string
 
 	UUID string
 

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -72,6 +72,7 @@ type Config struct {
 	RemoteHEInfo        string
 	Devices             DeviceOptions
 	NoHostname          bool
+	Models              bool
 }
 
 type Transform interface {


### PR DESCRIPTION
This PR resolves #91.
Originally, `GPUDevice` was like 'nvidia0'. And it could be made using `GPU` variable at receiver. So, I modify GPUDevice to Model without adding variable.

before: `device="nvidia0"`
after: `device="Teslav100-1"`

Signed-off-by: Jeong Ji Won <poiu8944@gmail.com>