### PR TITLE
Ensure go test does not trigger vet warnings.

### DIFF
--- a/bindings/go/dcgm/admin.go
+++ b/bindings/go/dcgm/admin.go
@@ -304,11 +304,11 @@ func checkHostengineVersion() (err error) {
 
 	heVersion, err := semver.NewVersion(he[1])
 	if err != nil {
-		return fmt.Errorf("Could not determine remote version ", err)
+		return fmt.Errorf("Could not determine remote version: %v", err)
 	}
 	myVersion, err := semver.NewVersion(my[1])
 	if err != nil {
-		return fmt.Errorf("Could not determine local version ", err)
+		return fmt.Errorf("Could not determine local version: %v", err)
 	}
 	if heVersion.Major() != myVersion.Major() {
 		return fmt.Errorf("remote %v != local %v", he[1], my[1])


### PR DESCRIPTION
This is the result of a go test prior to this PR:

```
# github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm
./admin.go:307:20: Errorf call has arguments but no formatting directives
./admin.go:311:20: Errorf call has arguments but no formatting directives
FAIL	github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm [build failed]
FAIL
```
Signed-off-by: Ingvar <imagineaclevernamehere@gmail.com>